### PR TITLE
Fix import paths

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"strings"
 
-	"cryptoscope.co/go/secretstream/boxstream"
-	"cryptoscope.co/go/secretstream/secrethandshake"
+	"github.com/cryptix/secretstream/boxstream"
+	"github.com/cryptix/secretstream/secrethandshake"
 	"github.com/agl/ed25519"
 )
 

--- a/net_test.go
+++ b/net_test.go
@@ -25,7 +25,7 @@ import (
 	"net"
 	"testing"
 
-	"cryptoscope.co/go/secretstream/secrethandshake"
+	"github.com/cryptix/secretstream/secrethandshake"
 )
 
 // test interface fullfilment

--- a/server.go
+++ b/server.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"strings"
 
-	"cryptoscope.co/go/secretstream/boxstream"
-	"cryptoscope.co/go/secretstream/secrethandshake"
+	"github.com/cryptix/secretstream/boxstream"
+	"github.com/cryptix/secretstream/secrethandshake"
 )
 
 // Server can create net.Listeners


### PR DESCRIPTION
The import path `cryptoscope.co` currently is not working. If this is temporary then please disregard!