### PR TITLE
net_test: add Close() after Write() test

### DIFF
--- a/boxstream/box.go
+++ b/boxstream/box.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"log"
 
 	"golang.org/x/crypto/nacl/secretbox"
 )
@@ -80,6 +81,7 @@ func (b *Boxer) loop() {
 		if err != nil {
 			running = false
 			if err2 := b.input.CloseWithError(err); err2 != nil {
+				log.Print("Boxer/CloseWithErr: ", err)
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -65,11 +65,11 @@ func (c *Client) NewDialer(pubKey [ed25519.PublicKeySize]byte) (Dialer, error) {
 		deKey, deNonce := state.GetBoxstreamDecKeys()
 
 		boxed := Conn{
-			Reader: boxstream.NewUnboxer(conn, &deNonce, &deKey),
-			Writer: boxstream.NewBoxer(conn, &enNonce, &enKey),
-			conn:   conn,
-			local:  c.kp.Public[:],
-			remote: state.Remote(),
+			Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
+			WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
+			conn:        conn,
+			local:       c.kp.Public[:],
+			remote:      state.Remote(),
 		}
 
 		return boxed, nil

--- a/conn.go
+++ b/conn.go
@@ -43,7 +43,7 @@ func (a Addr) PubKey() []byte {
 // Conn is a boxstream wrapped net.Conn
 type Conn struct {
 	io.Reader
-	io.Writer
+	io.WriteCloser
 	conn net.Conn
 
 	// public keys
@@ -52,7 +52,7 @@ type Conn struct {
 
 // Close closes the underlying net.Conn
 func (c Conn) Close() error {
-	return c.conn.Close()
+	return c.WriteCloser.Close()
 }
 
 // LocalAddr returns the local net.Addr with the local public key

--- a/server.go
+++ b/server.go
@@ -66,11 +66,11 @@ func ServerOnce(conn net.Conn, secretKey secrethandshake.EdKeyPair, appKey []byt
 
 	remote := state.Remote()
 	boxed := Conn{
-		Reader: boxstream.NewUnboxer(conn, &deNonce, &deKey),
-		Writer: boxstream.NewBoxer(conn, &enNonce, &enKey),
-		conn:   conn,
-		local:  secretKey.Public[:],
-		remote: remote[:],
+		Reader:      boxstream.NewUnboxer(conn, &deNonce, &deKey),
+		WriteCloser: boxstream.NewBoxer(conn, &enNonce, &enKey),
+		conn:        conn,
+		local:       secretKey.Public[:],
+		remote:      remote[:],
 	}
 
 	return boxed, nil


### PR DESCRIPTION
This test is currently failing. Close() does not block until
Write() has finished and thus leads to an EOF error in
io.ReadFull()